### PR TITLE
Remove `branch: master` from appveyor.yml deploy conditions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,6 @@ deploy:
     draft: false
     prerelease: false
     on:
-      branch: master
       appveyor_repo_tag: true
       ARCHITECTURE: x86
 
@@ -55,6 +54,5 @@ deploy:
     draft: false
     prerelease: false
     on:
-      branch: master
       appveyor_repo_tag: true
       ARCHITECTURE: x64


### PR DESCRIPTION
Adding a branch causes deploy on tags to be omitted.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>