### PR TITLE
Fix garbled relative paths on Windows

### DIFF
--- a/patches/static-entry-point.patch
+++ b/patches/static-entry-point.patch
@@ -1,4 +1,4 @@
-From 3d9945f2676ce1d6e7eaa5ab81441607a37487b8 Mon Sep 17 00:00:00 2001
+From 46bd06e9f1c93ee15b6e9c251801f632431a1b56 Mon Sep 17 00:00:00 2001
 From: Juan Cruz Viotti <jviotti@openmailbox.org>
 Date: Thu, 10 Nov 2016 13:15:09 +0200
 Subject: [PATCH] main: lock entry point to "index.js" in the current directory
@@ -10,10 +10,10 @@ and pass every arguments to it.
 Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>
 ---
  node.gyp                  |  1 +
- src/node_main.cc          | 15 +++++++--
- src/static-entry-point.cc | 77 +++++++++++++++++++++++++++++++++++++++++++++++
- src/static-entry-point.h  | 37 +++++++++++++++++++++++
- 4 files changed, 128 insertions(+), 2 deletions(-)
+ src/node_main.cc          | 15 ++++++++--
+ src/static-entry-point.cc | 75 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/static-entry-point.h  | 38 ++++++++++++++++++++++++
+ 4 files changed, 127 insertions(+), 2 deletions(-)
  create mode 100644 src/static-entry-point.cc
  create mode 100644 src/static-entry-point.h
 
@@ -69,10 +69,10 @@ index bde3975..cff9024 100644
  #endif
 diff --git a/src/static-entry-point.cc b/src/static-entry-point.cc
 new file mode 100644
-index 0000000..c77653d
+index 0000000..a4fd834
 --- /dev/null
 +++ b/src/static-entry-point.cc
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,75 @@
 +#include "static-entry-point.h"
 +
 +namespace entry {
@@ -95,17 +95,15 @@ index 0000000..c77653d
 +}
 +
 +char *GetStaticFilePath(char **argv) {
-+  char *file = (char *)malloc(MAXPATHLEN);
++  char *file = (char *)calloc(MAXPATHLEN, sizeof(char));
 +  if (file == NULL) return NULL;
 +#ifdef _WIN32
-+  char *directory = (char *)calloc(MAXPATHLEN, sizeof(char));
-+  if (!strcat(directory, argv[0])) return NULL;
-+  char *delimiter = strrchr(directory, '\\');
++  if (!GetFullPathName(argv[0], MAXPATHLEN, file, NULL)) return NULL;
++  char *delimiter = strrchr(file, '\\');
 +  if (delimiter) delimiter[0] = 0;
 +#else
-+  char *directory = dirname(argv[0]);
++  if (!strcat(file, dirname(argv[0]))) return NULL;
 +#endif
-+  if (!strcat(file, directory)) return NULL;
 +  if (!strcat(file, STATIC_FILE_NAME)) return NULL;
 +  return file;
 +}
@@ -152,10 +150,10 @@ index 0000000..c77653d
 +}  // namespace entry
 diff --git a/src/static-entry-point.h b/src/static-entry-point.h
 new file mode 100644
-index 0000000..d900b30
+index 0000000..dfe650d
 --- /dev/null
 +++ b/src/static-entry-point.h
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,38 @@
 +#ifndef SRC_STATIC_ENTRY_POINT_H_
 +#define SRC_STATIC_ENTRY_POINT_H_
 +
@@ -167,6 +165,7 @@ index 0000000..d900b30
 +#include <sys/param.h>
 +#include <libgen.h>
 +#else
++#include <windows.h>
 +#define MAXPATHLEN 1024
 +#endif
 +
@@ -194,5 +193,5 @@ index 0000000..d900b30
 +
 +#endif  // SRC_STATIC_ENTRY_POINT_H_
 -- 
-2.10.2
+2.8.3
 


### PR DESCRIPTION
We attempt to get the directory name of the node binary location by
removing the file name of `argv[0]` by finding the last backward slash,
however if the node binary is called from the same directory (e.g:
`node.exe`), there is no backward slash, and the directory path is
garbled.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>